### PR TITLE
Fix failing test: Update TestPayloadParser to use Blocks instead of deprecated Fragments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,15 +378,3 @@ redisDictionary.SaveCorrelation(key1, key2);
 var value = redisDictionary.Get(key);
 var correlated = redisDictionary.GetCorrelation(key);
 ```
-
----
-
-Issue to solve: https://github.com/xlab2016/space_db_public/issues/7
-Your prepared branch: issue-7-bb0fa28eaaa8
-Your prepared working directory: /tmp/gh-issue-solver-1762901095118
-Your forked repository: konard/space_db_public
-Original repository (upstream): xlab2016/space_db_public
-
-Proceed.
-
-Run timestamp: 2025-11-11T22:45:00.754Z


### PR DESCRIPTION
## Summary

This PR fixes the failing test `PayloadParserBaseTests.ParseAsync_WithDefaultImplementation_ShouldCreateResult` by updating the `TestPayloadParser` implementation to use the new `Blocks`-based hierarchical structure instead of the deprecated `Fragments` property.

## Problem

The test was failing with:
```
Expected result.Fragments to contain 1 item(s), but found 0: {empty}.
```

### Root Cause

1. The `ParsedResource.Fragments` property (ParsedResource.cs:33-57) is deprecated and replaced with a `Blocks`-based structure
2. The `Fragments` property getter returns flattened fragments from `Blocks.SelectMany(b => b.Fragments).ToList()`
3. When `result.Fragments.Add()` was called in the test, it called the **getter** which returned an empty list from empty Blocks, added to that temporary list, but never persisted it back
4. Result: The fragment was added to a temporary list that got discarded, leaving `result.Fragments` empty

## Solution

Updated `TestPayloadParser.ParseAsync()` (PayloadParserBaseTests.cs:39-72) to properly create a `ContentBlock` containing the fragments:

```csharp
// Before (incorrect):
result.Fragments.Add(new ContentFragment { ... });

// After (correct):
var fragment = new ContentFragment { ... };
result.Blocks.Add(new ContentBlock
{
    Content = payload,
    Type = "test_block",
    Order = 0,
    Fragments = new List<ContentFragment> { fragment }
});
```

This ensures the deprecated `Fragments` property getter correctly returns the fragments through the `Blocks` property.

## Testing

✅ The specific failing test now passes:
```
Passed SpaceDb.Tests.Services.Parsers.PayloadParserBaseTests.ParseAsync_WithDefaultImplementation_ShouldCreateResult
```

✅ All 113 tests pass with no regressions:
```
Test Run Successful.
Total tests: 113
     Passed: 113
```

## Changes

- **Modified**: `src/SpaceDb.Tests/Services/Parsers/PayloadParserBaseTests.cs`
  - Updated `TestPayloadParser.ParseAsync()` to use `Blocks` instead of deprecated `Fragments.Add()`

Fixes #7

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)